### PR TITLE
Set up

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "athenas-back",
   "version": "1.0.0",
   "description": "",
-  "main": "./dist/index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "start": "node ./dist/index.js",
-    "build": "tsc",
-    "dev": "nodemon",
+    "start": "node dist/index.js ",
+    "build": "rimraf ./dist && tsc",
+    "dev": "tsnd --respawn --clear src/index.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -30,7 +30,8 @@
     "@types/express": "^5.0.0",
     "@types/morgan": "^1.9.9",
     "nodemon": "^3.1.7",
-    "ts-node": "^10.9.2",
+    "rimraf": "^6.0.1",
+    "ts-node-dev": "^2.0.0",
     "typescript": "^5.6.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,17 @@
 {
-    "include": ["src/**/*.ts"],
-    "exclude":["node_modules", "dist"],
-    "compilerOptions": {
-        "target": "es2016",
-        "module": "commonjs",
-        "outDir": "./dist",
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "strict": true,
-        "skipLibCheck": true
-    }
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"],
+  "compilerOptions": {
+    "target": "es2016",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
+    "noImplicitAny": true
+  }
 }
-
-


### PR DESCRIPTION
feat(tsconfig): add strict compilation rules and config adjustments

- Enable `strictNullChecks`, `strictPropertyInitialization`, and `strictFunctionTypes`.
- Add `noImplicitAny` to prevent implicit `any` usage.
- Set `outDir` to compile output into the `dist` folder.
- scripts for start, run build, run dev properly setted
